### PR TITLE
Added support for sending iCal messages in the "alt_attach" mail type

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2043,6 +2043,11 @@ class PHPMailer
                 $body .= $this->getBoundary($this->boundary[2], $bodyCharSet, 'text/html', $bodyEncoding);
                 $body .= $this->encodeString($this->Body, $bodyEncoding);
                 $body .= $this->LE . $this->LE;
+	            if (!empty($this->Ical)) {
+		            $body .= $this->getBoundary($this->boundary[2], '', 'text/calendar; method=REQUEST', '');
+		            $body .= $this->encodeString($this->Ical, $this->Encoding);
+		            $body .= $this->LE . $this->LE;
+	            }
                 $body .= $this->endBoundary($this->boundary[2]);
                 $body .= $this->LE;
                 $body .= $this->attachAll('attachment', $this->boundary[1]);


### PR DESCRIPTION
Copied from the "alt" mail type when creating the body, so now you can send an iCal attachment inline together with regular attachments (instead of only in mails without other attachments)
